### PR TITLE
Strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,28 +17,28 @@ var PATH_REGEXP = new RegExp([
 ].join('|'), 'g');
 
 function reversePath(path, params, options) {
-    this.index = 0;
-    this.params = params || {};
-    this.options = options || {};
+    var index = 0;
+    params = params || {};
+    options = options || {};
 
     return path.replace(PATH_REGEXP, replace);
-}
 
-function replace(match, escaped, prefix, key, capture, group, optional, escape) {
-    if(escaped) return escaped;
-    if(escape) return escape;
+    function replace(match, escaped, prefix, key, capture, group, optional, escape) {
+        if(escaped) return escaped;
+        if(escape) return escape;
 
-    prefix = prefix || '';
+        prefix = prefix || '';
 
-    var value = this.params[key || this.index++];
+        var value = params[key || index++];
 
-    if(value === undefined) {
-        if(optional) {
-            value = '';
-        } else {
-            throw new Error('Parameter "' + key + '" is required.');
+        if(value === undefined) {
+            if(optional) {
+                value = '';
+            } else {
+                throw new Error('Parameter "' + key + '" is required.');
+            }
         }
-    }
 
-    return prefix + value;
+        return prefix + value;
+    }
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+
+'use strict';
+
 module.exports = reversePath;
 
 // regex from https://github.com/component/path-to-regexp

--- a/test.js
+++ b/test.js
@@ -57,7 +57,7 @@ describe('reverse-path', function() {
 
     afterEach(function () {
 
-      assert.equal(global.params, undefined);
+      assert.strictEqual(global.params, undefined);
     });
 
     it('should throw an exception when required keys aren\'t provided', function() {

--- a/test.js
+++ b/test.js
@@ -54,6 +54,12 @@ var TESTS = [
 ];
 
 describe('reverse-path', function() {
+
+    afterEach(function () {
+
+      assert.equal(global.params, undefined);
+    });
+
     it('should throw an exception when required keys aren\'t provided', function() {
         assert.throws(function() {
             reversePath('/:foo/:bar', { foo: 'test' });


### PR DESCRIPTION
This pull request ensures that the `params` object created cannot be added to the `global` namespace.
